### PR TITLE
Add a working podcast link

### DIFF
--- a/src/docs/sources.mdx
+++ b/src/docs/sources.mdx
@@ -96,7 +96,7 @@ Balaji lists out all of his content on his website.
 
 ### Other Great Podcasts
 
-[Podcasts](Best%20of%20Balaji%20f78d3a43921448ad9a2ab72efc9e03fd/Podcasts%2020829cea7f914d06b4d4f897223b1db6.md)
+[Podcasts](https://alias.co/balaji-srinivasan/podcasts)
 
 ---
 


### PR DESCRIPTION
The podcasts link doesn't go anywhere. The Alias page could work as a place to find more Balaji podcasts.